### PR TITLE
chore: NO-ISSUE - GitHub actions - renovate

### DIFF
--- a/.github/renovate-global.json
+++ b/.github/renovate-global.json
@@ -1,6 +1,18 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "branchPrefix": "github-renovate/",
+  "globalExtends": [
+    "config:best-practices",
+    "group:goOpenapi",
+    "group:kubernetes",
+    "group:opentelemetry-goMonorepo",
+    "group:opentelemetry-go-contribMonorepo",
+    "group:protobufMonorepo"
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "dependencyDashboard": true,
   "dependencyDashboardTitle": "Dependency Dashboard self-hosted",
   "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
   "onboarding": true,


### PR DESCRIPTION
This pull request includes changes to the `.github/renovate-global.json` file to enhance the configuration for dependency management. 

The most important changes include:

* Added global extensions to follow best practices and group dependencies. (`config:best-practices`, `group:goOpenapi`, `group:kubernetes`, `group:opentelemetry-goMonorepo`, `group:opentelemetry-go-contribMonorepo`, `group:protobufMonorepo`)
* Added a label for dependency updates. (`dependencies`)
* Enabled the dependency dashboard for better tracking of dependency updates.