### PR TITLE
feat: CU-8697896e6 - Add golang static analysis in GitHub actions pipelines

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -20,6 +20,8 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
+  checks: write
 
 jobs:
   changes:
@@ -66,7 +68,15 @@ jobs:
         run: |
           go mod tidy
           git diff --exit-code -- .
-
+      - name: Check go vet
+        run: |
+          go vet -json ./... 2> go-vet.out
+      - name: Upload go-vet report
+        uses: actions/upload-artifact@v4.6.1
+        with:
+          name: go-vet-report
+          path: go-vet.out
+  
   build-go:
     name: Build & cache Go code
     if: ${{ needs.changes.outputs.backend == 'true' }}
@@ -92,9 +102,6 @@ jobs:
         run: make build-local
 
   lint-go:
-    permissions:
-      contents: read  # for actions/checkout to fetch code
-      pull-requests: read  # for golangci/golangci-lint-action to fetch pull requests
     name: Lint Go code
     if: ${{ needs.changes.outputs.backend == 'true' }}
     runs-on: ubuntu-24.04
@@ -112,7 +119,12 @@ jobs:
         with:
           # renovate: datasource=go packageName=github.com/golangci/golangci-lint versioning=regex:^v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)?$
           version: v1.62.2
-          args: --verbose
+          args: --verbose --out-format=checkstyle:golangci-lint-report.xml
+      - name: Upload golangci-lint report
+        uses: actions/upload-artifact@v4.6.1
+        with:
+          name: golangci-lint-report
+          path: golangci-lint-report.xml
 
   test-go:
     name: Run unit tests for Go packages
@@ -140,6 +152,43 @@ jobs:
       - name: Download and vendor all required packages
         run: |
           go mod download
+      - name: Setup gotestsum
+        uses: autero1/action-gotestsum@v2.0.0
+        with:
+          gotestsum_version: 1.12.0
       - name: Run all unit tests
-        run: make test-local
+        run: gotestsum --jsonfile test-report.out -- -coverprofile=coverage.out ./...
+      - name: Upload test report
+        uses: actions/upload-artifact@v4.6.1
+        with:
+          name: test-report
+          path: |
+            test-report.out
+            coverage.out
 
+  sonarqube:
+    runs-on: ubuntu-latest
+    needs:
+      - check-go
+      - lint-go
+      - test-go
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Disabling shallow clones is recommended for improving the relevancy of reporting
+          fetch-depth: 0
+      - name: Download SAST reports
+        uses: actions/download-artifact@v4.1.9
+        with:
+          path: ./sast-reports
+          merge-multiple: true
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v5.0.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: >
+            -Dsonar.go.tests.reportPaths=./sast-reports/test-report.out
+            -Dsonar.go.coverage.reportPaths=./sast-reports/coverage.out
+            -Dsonar.go.govet.reportPaths=./sast-reports/go-vet.out
+            -Dsonar.go.golangci-lint.reportPaths=./sast-reports/golangci-lint-report.xml

--- a/Makefile
+++ b/Makefile
@@ -19,30 +19,34 @@ gogen:
 	export GO111MODULE=off
 	go generate ./...
 
-.PHONY: mod-download-local
-mod-download-local:
+.PHONY: mod-download
+mod-download:
 	go mod download && go mod tidy # go mod download changes go.sum https://github.com/golang/go/issues/42970
 
-.PHONY: mod-vendor-local
-mod-vendor-local: mod-download-local
+.PHONY: mod-vendor
+mod-vendor: mod-download
 	go mod vendor
 
 # Run linter on the code (local version)
-.PHONY: lint-local
-lint-local:
+.PHONY: lint
+lint:
 	golangci-lint --version
 	# NOTE: If you get a "Killed" OOM message, try reducing the value of GOGC
 	# See https://github.com/golangci/golangci-lint#memory-usage-of-golangci-lint
 	GOGC=$(CANO_LINT_GOGC) GOMAXPROCS=2 golangci-lint run --fix --verbose
 
+.PHONY: vet
+vet:
+	go vet -json ./...
+
 # Build all Go code (local version)
-.PHONY: build-local
-build-local:
+.PHONY: build
+build:
 	go build -v `go list ./...`
 
 # Run all unit tests (local version)
-.PHONY: test-local
-test-local:
+.PHONY: test
+test:
 	go test -v `go list ./...`
 
 .PHONY: help


### PR DESCRIPTION
This pull request includes several updates to the CI/CD pipeline and the Makefile to enhance the Go code build, linting, testing, and reporting processes. The most important changes include adding permissions, updating job steps in the CI workflow, and modifying Makefile targets.

### CI/CD Pipeline Enhancements:

* Added permissions for `pull-requests: read` and `checks: write` in `.github/workflows/ci-build.yaml`.
* Introduced a new job step to run `go vet` and upload the report as an artifact in `.github/workflows/ci-build.yaml`.
* Updated the `lint-go` job to use `golangci-lint` with `checkstyle` format and upload the report as an artifact in `.github/workflows/ci-build.yaml`.
* Added steps to the `test-go` job to set up `gotestsum`, run tests with coverage, and upload the test report in `.github/workflows/ci-build.yaml`.
* Introduced a new `sonarqube` job to perform a SonarQube scan using various reports in `.github/workflows/ci-build.yaml`.

### Makefile Updates:

* Renamed targets to remove `-local` suffix and added new targets for `vet`, `mod-download`, `mod-vendor`, `lint`, `build`, and `test` in `Makefile`.