### PR TITLE
feat: CU-8697896e6 - Add golang static analysis in GitHub actions pip…

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -28,7 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       backend: ${{ steps.filter.outputs.backend_any_changed }}
-      frontend: ${{ steps.filter.outputs.frontend_any_changed }}
       docs: ${{ steps.filter.outputs.docs_any_changed }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -38,13 +37,9 @@ jobs:
           # Any file which is not under docs/, ui/ or is not a markdown file is counted as a backend file
           files_yaml: |
             backend:
-              - '!ui/**'
               - '!**.md'            
               - '!**/*.md'
               - '!docs/**'
-            frontend:
-              - 'ui/**'
-              - Dockerfile
             docs:
               - 'docs/**'
 
@@ -126,6 +121,26 @@ jobs:
           name: golangci-lint-report
           path: golangci-lint-report.xml
 
+  hadolint-docker:
+    name: Lint Dockerfiles
+    if: ${{ needs.changes.outputs.backend == 'true' }}
+    runs-on: ubuntu-24.04
+    needs:
+      - changes
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile
+          output-file: hadolint-report.out
+          format: json
+      - name: Upload hadolint report
+        uses: actions/upload-artifact@v4.6.1
+        with:
+          name: hadolint-report
+          path: hadolint-report.out
+
   test-go:
     name: Run unit tests for Go packages
     if: ${{ needs.changes.outputs.backend == 'true' }}
@@ -192,3 +207,4 @@ jobs:
             -Dsonar.go.coverage.reportPaths=./sast-reports/coverage.out
             -Dsonar.go.govet.reportPaths=./sast-reports/go-vet.out
             -Dsonar.go.golangci-lint.reportPaths=./sast-reports/golangci-lint-report.xml
+            -Dsonar.docker.hadolint.reportPaths=./saas-reports/hadolint-report.out

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,4 @@
+label-schema:
+  author: text
+  contact: email
+  license: spdx

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,20 @@ FROM golang:1.23@sha256:927112936d6b496ed95f55f362cc09da6e3e624ef868814c56d55bd7
 
 WORKDIR /go/src/github.com/kubecano/cano-collector
 
-COPY go.* ./
+COPY go.mod go.sum ./
 RUN go mod download
 
-COPY . .
-RUN go vet -v
-RUN go test -v
+COPY main.go .
+RUN go vet -v && go test -v
 
 RUN CGO_ENABLED=0 go build -o /go/bin/cano-collector
 
 FROM gcr.io/distroless/static-debian12@sha256:3f2b64ef97bd285e36132c684e6b2ae8f2723293d09aae046196cca64251acac
 
+LABEL author="KubeCano Team"
+LABEL contact="support@kubecano.com"
+LABEL license="Apache-2.0"
+LABEL org.opencontainers.image.title="cano-collector"
 LABEL org.opencontainers.image.source="https://github.com/kubecano/cano-collector"
 
 COPY --from=build /go/bin/cano-collector /


### PR DESCRIPTION
This pull request includes several changes to the CI build workflow and Dockerfile for the project. The most important changes include removing frontend-related configurations from the CI workflow, adding a new job for linting Dockerfiles, and updating the Dockerfile to improve the build process and add metadata labels.

Changes to CI build workflow:

* [`.github/workflows/ci-build.yaml`](diffhunk://#diff-b8790dc873e80c2f7f63bf198b4da0147787ad8954767b839967d29f65155e2cL31): Removed frontend-related configurations, including the `frontend` output and file paths for frontend files. [[1]](diffhunk://#diff-b8790dc873e80c2f7f63bf198b4da0147787ad8954767b839967d29f65155e2cL31) [[2]](diffhunk://#diff-b8790dc873e80c2f7f63bf198b4da0147787ad8954767b839967d29f65155e2cL41-L47)
* [`.github/workflows/ci-build.yaml`](diffhunk://#diff-b8790dc873e80c2f7f63bf198b4da0147787ad8954767b839967d29f65155e2cR124-R143): Added a new job `hadolint-docker` to lint Dockerfiles using `hadolint` and upload the report.
* [`.github/workflows/ci-build.yaml`](diffhunk://#diff-b8790dc873e80c2f7f63bf198b4da0147787ad8954767b839967d29f65155e2cR210): Updated the SonarQube configuration to include the hadolint report path.

Changes to Dockerfile:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L5-R18): Updated the `COPY` commands to only copy necessary files and combined `go vet` and `go test` commands into a single `RUN` instruction.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L5-R18): Added metadata labels for author, contact, license, and image title.

Additional configuration:

* [`.hadolint.yaml`](diffhunk://#diff-de883738d00a6be8bead71654b531242c752e7087aa41a1a5985a64f55c6301fR1-R4): Added label schema configuration for hadolint.…elines - Hadolint Docker