### PR TITLE
chore: Refactor and bump versions in pipeline

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -10,7 +10,10 @@ on:
 env:
   # Golang version to use across CI steps
   # renovate: datasource=golang-version packageName=golang
-  GOLANG_VERSION: '1.23.4'
+  GOLANG_VERSION: '1.24.0'
+  # GolangCI-Lint version to use across CI steps
+  # renovate: datasource=go packageName=github.com/golangci/golangci-lint versioning=regex:^v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)?$
+  GOLANGCI_LINT_VERSION: 'v1.64.6'
   GROUP_NAME: 'kubecano'
   PROJ_NAME: 'cano-collector'
 
@@ -112,8 +115,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
         with:
-          # renovate: datasource=go packageName=github.com/golangci/golangci-lint versioning=regex:^v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)?$
-          version: v1.64.6
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --verbose --out-format=checkstyle:golangci-lint-report.xml
       - name: Upload golangci-lint report
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1


### PR DESCRIPTION
This pull request includes updates to the CI configuration for the project. The most important changes include updating the Golang version and introducing a new environment variable for the GolangCI-Lint version.

Updates to CI configuration:

* [`.github/workflows/ci-build.yaml`](diffhunk://#diff-b8790dc873e80c2f7f63bf198b4da0147787ad8954767b839967d29f65155e2cL13-R16): Updated the Golang version to `1.24.0` and added a new environment variable for GolangCI-Lint version (`GOLANGCI_LINT_VERSION`) set to `v1.64.6`.
* [`.github/workflows/ci-build.yaml`](diffhunk://#diff-b8790dc873e80c2f7f63bf198b4da0147787ad8954767b839967d29f65155e2cL115-R118): Modified the `Run golangci-lint` job to use the new `GOLANGCI_LINT_VERSION` environment variable instead of a hardcoded version.