### PR TITLE
feat: CU-8697ep0yb - Add structured logger to Collector with slog or uber-go/zap - refactoring

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,4 @@
 issues:
-  exclude:
-    - SA5011
   max-issues-per-linter: 0
   max-same-issues: 0
   exclude-rules:

--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,7 @@ import (
 type Config struct {
 	AppName       string
 	AppVersion    string
+	AppEnv        string
 	LogLevel      string
 	SentryDSN     string
 	SentryEnabled bool
@@ -19,6 +20,7 @@ func LoadConfig() {
 	GlobalConfig = Config{
 		AppName:       getEnvString("APP_NAME", "cano-collector"),
 		AppVersion:    getEnvString("APP_VERSION", "dev"),
+		AppEnv:        getEnvString("APP_ENV", "development"),
 		LogLevel:      getEnvString("LOG_LEVEL", "info"),
 		SentryDSN:     getEnvString("SENTRY_DSN", ""),
 		SentryEnabled: getEnvBool("ENABLE_TELEMETRY", true),

--- a/config/config.go
+++ b/config/config.go
@@ -20,7 +20,7 @@ func LoadConfig() {
 	GlobalConfig = Config{
 		AppName:       getEnvString("APP_NAME", "cano-collector"),
 		AppVersion:    getEnvString("APP_VERSION", "dev"),
-		AppEnv:        getEnvString("APP_ENV", "development"),
+		AppEnv:        getEnvString("APP_ENV", "production"),
 		LogLevel:      getEnvString("LOG_LEVEL", "info"),
 		SentryDSN:     getEnvString("SENTRY_DSN", ""),
 		SentryEnabled: getEnvBool("ENABLE_TELEMETRY", true),

--- a/helm/cano-collector/templates/deployment.yaml
+++ b/helm/cano-collector/templates/deployment.yaml
@@ -66,6 +66,8 @@ spec:
           env:
             - name: "APP_VERSION"
               value: {{ .Chart.AppVersion | quote }}
+            - name: "APP_ENV"
+              value: {{ .Values.appEnv | quote }}
             - name: "LOG_LEVEL"
               value: {{ .Values.logLevel | quote }}
             - name: "ENABLE_TELEMETRY"

--- a/helm/cano-collector/values.yaml
+++ b/helm/cano-collector/values.yaml
@@ -15,6 +15,7 @@ image:
 
 sentry_dsn: https://4f1a66f025c60830fec303a094dcdf94@o1120648.ingest.sentry.io/6156573
 enableTelemetry: true
+appEnv: production
 logLevel: info
 ginMode: release
 

--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ func main() {
 	}
 	logger.Debug("Health checks registered")
 
-	r := router.SetupRouter(logger.GetLogger(), h)
+	r := router.SetupRouter(h)
 	logger.Debug("Router setup complete")
 
 	router.StartServer(r)

--- a/main.go
+++ b/main.go
@@ -18,11 +18,15 @@ func main() {
 	config.LoadConfig()
 
 	logger.InitLogger(config.GlobalConfig.LogLevel)
+	logger.Debug("Logger initialized")
 
 	if config.GlobalConfig.SentryEnabled {
 		if err := initSentry(config.GlobalConfig.SentryDSN); err != nil {
 			logger.Fatalf("Sentry initialization failed: %v", err)
 		}
+		logger.Debug("Sentry initialized")
+	} else {
+		logger.Debug("Sentry is disabled")
 	}
 
 	defer sentry.Flush(2 * time.Second)
@@ -31,8 +35,10 @@ func main() {
 	if err != nil {
 		logger.PanicF("Failed to register health checks: %v", err)
 	}
+	logger.Debug("Health checks registered")
 
 	r := router.SetupRouter(logger.GetLogger(), h)
+	logger.Debug("Router setup complete")
 
 	router.StartServer(r)
 }

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -8,6 +8,8 @@ import (
 )
 
 func RegisterHealthChecks() (*health.Health, error) {
+	logger.Debug("Starting health check registration")
+
 	h, err := health.New(health.WithComponent(
 		health.Component{
 			Name:    config.GlobalConfig.AppName,
@@ -19,5 +21,6 @@ func RegisterHealthChecks() (*health.Health, error) {
 		return nil, err
 	}
 
+	logger.Info("Health check registration completed successfully")
 	return h, nil
 }

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"go.uber.org/zap"
+
+	"github.com/kubecano/cano-collector/pkg/logger"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/hellofresh/health-go/v5"
@@ -14,6 +18,8 @@ import (
 )
 
 func TestRegisterHealthChecks(t *testing.T) {
+	l, _ := zap.NewDevelopment()
+	logger.SetLogger(l)
 	config.GlobalConfig = config.Config{
 		AppName:    "cano-collector",
 		AppVersion: "1.0.0",

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,99 +1,113 @@
 package logger
 
 import (
+	"sync"
+
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/kubecano/cano-collector/config"
 )
 
-var logger *zap.Logger
+var (
+	logger *zap.Logger
+	once   sync.Once
+)
 
 func InitLogger(level string) {
-	var logLevel zapcore.Level
+	once.Do(func() {
+		var logLevel zapcore.Level
 
-	switch level {
-	case "debug":
-		logLevel = zap.DebugLevel
-	case "info":
-		logLevel = zap.InfoLevel
-	case "warn":
-		logLevel = zap.WarnLevel
-	case "error":
-		logLevel = zap.ErrorLevel
-	default:
-		logLevel = zap.InfoLevel
-	}
+		switch level {
+		case "debug":
+			logLevel = zap.DebugLevel
+		case "info":
+			logLevel = zap.InfoLevel
+		case "warn":
+			logLevel = zap.WarnLevel
+		case "error":
+			logLevel = zap.ErrorLevel
+		default:
+			logLevel = zap.InfoLevel
+		}
 
-	zapConfig := zap.Config{
-		Encoding:         "json",
-		Development:      config.GlobalConfig.AppEnv != "production",
-		Level:            zap.NewAtomicLevelAt(logLevel),
-		OutputPaths:      []string{"stdout"},
-		ErrorOutputPaths: []string{"stderr"},
-		EncoderConfig: zapcore.EncoderConfig{
-			TimeKey:      "timestamp",
-			LevelKey:     "level",
-			MessageKey:   "message",
-			CallerKey:    "caller",
-			EncodeLevel:  zapcore.LowercaseLevelEncoder, // info, debug, error
-			EncodeTime:   zapcore.ISO8601TimeEncoder,
-			EncodeCaller: zapcore.ShortCallerEncoder,
-		},
-	}
+		zapConfig := zap.Config{
+			Encoding:         "json",
+			Development:      config.GlobalConfig.AppEnv != "production",
+			Level:            zap.NewAtomicLevelAt(logLevel),
+			OutputPaths:      []string{"stdout"},
+			ErrorOutputPaths: []string{"stderr"},
+			EncoderConfig: zapcore.EncoderConfig{
+				TimeKey:      "timestamp",
+				LevelKey:     "level",
+				MessageKey:   "message",
+				CallerKey:    "caller",
+				EncodeLevel:  zapcore.LowercaseLevelEncoder, // info, debug, error
+				EncodeTime:   zapcore.ISO8601TimeEncoder,
+				EncodeCaller: zapcore.ShortCallerEncoder,
+			},
+		}
 
-	var err error
-	logger, err = zapConfig.Build()
-	if err != nil {
-		panic("failed to initialize logger: " + err.Error())
-	}
+		var err error
+		logger, err = zapConfig.Build()
+		if err != nil {
+			panic("failed to initialize logger: " + err.Error())
+		}
+	})
+}
+
+func SetLogger(customLogger *zap.Logger) {
+	logger = customLogger
 }
 
 func GetLogger() *zap.Logger {
+	if logger == nil {
+		panic("Logger not initialized! Call InitLogger first.")
+	}
 	return logger
 }
 
 // Debug logs a message at DebugLevel. The message includes any fields passed at the log site.
 func Debug(args ...interface{}) {
-	logger.Sugar().Debug(args...)
+	GetLogger().Sugar().Debug(args...)
 }
 
 // Debugf logs a formatted message at DebugLevel. The message includes any fields passed at the log site.
 func Debugf(template string, args ...interface{}) {
-	logger.Sugar().Debugf(template, args...)
+	GetLogger().Sugar().Debugf(template, args...)
 }
 
 // Info logs a message at InfoLevel. The message includes any fields passed at the log site.
 func Info(args ...interface{}) {
-	logger.Sugar().Info(args...)
+	GetLogger().Sugar().Info(args...)
 }
 
 // Warn logs a message at WarnLevel. The message includes any fields passed at the log site.
 func Warn(args ...interface{}) {
-	logger.Sugar().Warn(args...)
+	GetLogger().Sugar().Warn(args...)
 }
 
 // Warnf logs a formatted message at WarnLevel. The message includes any fields passed at the log site.
 func Warnf(template string, args ...interface{}) {
-	logger.Sugar().Warnf(template, args...)
+	GetLogger().Sugar().Warnf(template, args...)
 }
 
 // Errorf logs a message at ErrorLevel. The message includes any fields passed at the log site.
 func Errorf(template string, args ...interface{}) {
-	logger.Sugar().Errorf(template, args...)
+	GetLogger().Sugar().Errorf(template, args...)
 }
 
 // Fatalf logs a message at FatalLevel and calls os.Exit. The message includes any fields passed at the log site.
 func Fatalf(template string, args ...interface{}) {
-	logger.Sugar().Fatalf(template, args...)
+	GetLogger().Sugar().Fatalf(template, args...)
 }
 
 // Fatal logs a message at FatalLevel and calls os.Exit. The message includes any fields passed at the log site.
 func Fatal(args ...interface{}) {
-	logger.Sugar().Fatal(args...)
+	GetLogger().Sugar().Fatal(args...)
 }
 
 // PanicF logs a message at PanicLevel and panics. The message includes any fields passed at the log site.
 func PanicF(template string, args ...interface{}) {
-	logger.Sugar().Panicf(template, args...)
+	GetLogger().Sugar().Panicf(template, args...)
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,9 +1,10 @@
 package logger
 
 import (
-	"github.com/kubecano/cano-collector/config"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/kubecano/cano-collector/config"
 )
 
 var logger *zap.Logger
@@ -52,22 +53,47 @@ func GetLogger() *zap.Logger {
 	return logger
 }
 
+// Debug logs a message at DebugLevel. The message includes any fields passed at the log site.
+func Debug(args ...interface{}) {
+	logger.Sugar().Debug(args...)
+}
+
+// Debugf logs a formatted message at DebugLevel. The message includes any fields passed at the log site.
+func Debugf(template string, args ...interface{}) {
+	logger.Sugar().Debugf(template, args...)
+}
+
+// Info logs a message at InfoLevel. The message includes any fields passed at the log site.
 func Info(args ...interface{}) {
 	logger.Sugar().Info(args...)
 }
 
+// Warn logs a message at WarnLevel. The message includes any fields passed at the log site.
+func Warn(args ...interface{}) {
+	logger.Sugar().Warn(args...)
+}
+
+// Warnf logs a formatted message at WarnLevel. The message includes any fields passed at the log site.
+func Warnf(template string, args ...interface{}) {
+	logger.Sugar().Warnf(template, args...)
+}
+
+// Errorf logs a message at ErrorLevel. The message includes any fields passed at the log site.
 func Errorf(template string, args ...interface{}) {
 	logger.Sugar().Errorf(template, args...)
 }
 
+// Fatalf logs a message at FatalLevel and calls os.Exit. The message includes any fields passed at the log site.
 func Fatalf(template string, args ...interface{}) {
 	logger.Sugar().Fatalf(template, args...)
 }
 
+// Fatal logs a message at FatalLevel and calls os.Exit. The message includes any fields passed at the log site.
 func Fatal(args ...interface{}) {
 	logger.Sugar().Fatal(args...)
 }
 
+// PanicF logs a message at PanicLevel and panics. The message includes any fields passed at the log site.
 func PanicF(template string, args ...interface{}) {
 	logger.Sugar().Panicf(template, args...)
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"github.com/kubecano/cano-collector/config"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -23,8 +24,9 @@ func InitLogger(level string) {
 		logLevel = zap.InfoLevel
 	}
 
-	config := zap.Config{
+	zapConfig := zap.Config{
 		Encoding:         "json",
+		Development:      config.GlobalConfig.AppEnv != "production",
 		Level:            zap.NewAtomicLevelAt(logLevel),
 		OutputPaths:      []string{"stdout"},
 		ErrorOutputPaths: []string{"stderr"},
@@ -40,7 +42,7 @@ func InitLogger(level string) {
 	}
 
 	var err error
-	logger, err = config.Build()
+	logger, err = zapConfig.Build()
 	if err != nil {
 		panic("failed to initialize logger: " + err.Error())
 	}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -5,6 +5,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"go.uber.org/zap"
+
+	"github.com/kubecano/cano-collector/pkg/logger"
+
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -13,6 +17,8 @@ import (
 )
 
 func TestRegisterMetrics(t *testing.T) {
+	l, _ := zap.NewDevelopment()
+	logger.SetLogger(l)
 	assert.NotPanics(t, func() {
 		RegisterMetrics()
 	})
@@ -20,6 +26,8 @@ func TestRegisterMetrics(t *testing.T) {
 
 func TestPrometheusMiddleware(t *testing.T) {
 	gin.SetMode(gin.TestMode)
+	l, _ := zap.NewDevelopment()
+	logger.SetLogger(l)
 	router := gin.New()
 
 	// Reset the default Prometheus registry

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -27,6 +27,8 @@ import (
 func SetupRouter(logger *zap.Logger, health *health.Health) *gin.Engine {
 	r := gin.Default()
 
+	logger.Debug("Setting up router")
+
 	r.Use(sentrygin.New(sentrygin.Options{
 		Repanic:         true,
 		WaitForDelivery: false,
@@ -66,6 +68,7 @@ func SetupRouter(logger *zap.Logger, health *health.Health) *gin.Engine {
 	r.GET("/readyz", gin.WrapH(health.Handler()))
 	r.GET("/healthz", gin.WrapH(health.Handler()))
 
+	logger.Debug("Router setup complete")
 	return r
 }
 

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -9,8 +9,6 @@ import (
 	"syscall"
 	"time"
 
-	"go.uber.org/zap"
-
 	"github.com/kubecano/cano-collector/pkg/logger"
 
 	"github.com/hellofresh/health-go/v5"
@@ -24,7 +22,7 @@ import (
 	"github.com/kubecano/cano-collector/pkg/metrics"
 )
 
-func SetupRouter(logger *zap.Logger, health *health.Health) *gin.Engine {
+func SetupRouter(health *health.Health) *gin.Engine {
 	r := gin.Default()
 
 	logger.Debug("Setting up router")
@@ -46,11 +44,11 @@ func SetupRouter(logger *zap.Logger, health *health.Health) *gin.Engine {
 	//   - Logs all requests, like a combined access and error log.
 	//   - Logs to stdout.
 	//   - RFC3339 with UTC time format.
-	r.Use(ginzap.Ginzap(logger, time.RFC3339, true))
+	r.Use(ginzap.Ginzap(logger.GetLogger(), time.RFC3339, true))
 
 	// Logs all panic to error log
 	//   - stack means whether output the stack info.
-	r.Use(ginzap.RecoveryWithZap(logger, true))
+	r.Use(ginzap.RecoveryWithZap(logger.GetLogger(), true))
 
 	// Set up routes
 	metrics.RegisterMetrics()

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -11,6 +11,8 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/kubecano/cano-collector/pkg/logger"
+
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
@@ -19,7 +21,8 @@ import (
 func TestHelloWorld(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	l, _ := zap.NewDevelopment()
-	router := SetupRouter(l, nil)
+	logger.SetLogger(l)
+	router := SetupRouter(nil)
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest(http.MethodGet, "/", nil)
@@ -32,7 +35,8 @@ func TestHelloWorld(t *testing.T) {
 func TestStartServer(t *testing.T) {
 	prometheus.DefaultRegisterer = prometheus.NewRegistry()
 	l, _ := zap.NewDevelopment()
-	router := SetupRouter(l, nil)
+	logger.SetLogger(l)
+	router := SetupRouter(nil)
 
 	srv := &http.Server{
 		Addr:    ":8080",
@@ -119,7 +123,8 @@ func TestMetricsEndpoint(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	prometheus.DefaultRegisterer = prometheus.NewRegistry()
 	l, _ := zap.NewDevelopment()
-	router := SetupRouter(l, nil)
+	logger.SetLogger(l)
+	router := SetupRouter(nil)
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest(http.MethodGet, "/metrics", nil)


### PR DESCRIPTION
This pull request introduces several changes to enhance logging, configuration, and the overall structure of the codebase. The key changes include adding a new `AppEnv` configuration, improving the logger initialization, and adding debug logs throughout the application.

### Configuration Enhancements:
* Added `AppEnv` configuration to `config/config.go` and updated the `LoadConfig` function to include `AppEnv` with a default value of "production". (`[[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R11)`, `[[2]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R23)`)
* Updated `helm/cano-collector/templates/deployment.yaml` and `helm/cano-collector/values.yaml` to include `AppEnv` configuration. (`[[1]](diffhunk://#diff-bbb3e0b78cdb28d784b5c2a8e9e73359be26a944070bdb6da879475e399f6731R69-R70)`, `[[2]](diffhunk://#diff-ce6f1917fc0ae8e78410e442fe458b577739522abfee1f045a0a61bc575a5f7fR18)`)

### Logger Improvements:
* Introduced a singleton pattern for logger initialization in `pkg/logger/logger.go` to ensure the logger is only initialized once. (`[[1]](diffhunk://#diff-c1dc2eb1e149a1dc7ecd5cb474e167fb456eb7ad0ea0256cf62fba693a89af79R4-R18)`, `[[2]](diffhunk://#diff-c1dc2eb1e149a1dc7ecd5cb474e167fb456eb7ad0ea0256cf62fba693a89af79L26-R36)`)
* Added new logging methods (`Debug`, `Debugf`, `Info`, `Warn`, `Warnf`, `Errorf`, `Fatal`, `Fatalf`, `PanicF`) for different log levels in `pkg/logger/logger.go`. (`[pkg/logger/logger.goL43-R112](diffhunk://#diff-c1dc2eb1e149a1dc7ecd5cb474e167fb456eb7ad0ea0256cf62fba693a89af79L43-R112)`)
* Updated the logger initialization to consider the `AppEnv` configuration for setting the development mode. (`[pkg/logger/logger.goL26-R36](diffhunk://#diff-c1dc2eb1e149a1dc7ecd5cb474e167fb456eb7ad0ea0256cf62fba693a89af79L26-R36)`)

### Debug Logging:
* Added debug logs in various parts of the application to trace execution, including initialization of the logger, Sentry, health checks, router setup, and Prometheus metrics registration. (`[[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R21-R29)`, `[[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R38-R41)`, `[[3]](diffhunk://#diff-b7f1feaa038882966a9d30e0b96e476dccccc2608dd8a660f80767dbbc635b6fR11-R12)`, `[[4]](diffhunk://#diff-b7f1feaa038882966a9d30e0b96e476dccccc2608dd8a660f80767dbbc635b6fR24)`, `[[5]](diffhunk://#diff-4bc91a74bc47b8467cdcd25a7e3fe1651dbe44907f478377eca31b982f444f23R22-R32)`, `[[6]](diffhunk://#diff-4bc91a74bc47b8467cdcd25a7e3fe1651dbe44907f478377eca31b982f444f23R41)`, `[[7]](diffhunk://#diff-06404baf0ccd8477ead1249463f8f394030eb63c6c3bcff3fe1fea2368150673L27-R29)`, `[[8]](diffhunk://#diff-06404baf0ccd8477ead1249463f8f394030eb63c6c3bcff3fe1fea2368150673L47-R51)`, `[[9]](diffhunk://#diff-06404baf0ccd8477ead1249463f8f394030eb63c6c3bcff3fe1fea2368150673R69)`)

### Test Enhancements:
* Updated tests to use the new logger setup by setting the logger in test files (`pkg/health/health_test.go`, `pkg/metrics/metrics_test.go`, `pkg/router/router_test.go`). (`[[1]](diffhunk://#diff-168486be9e126a8de1f0588534a9bf2fd49261555cbdc3759a5be2b1d2825cd3R7-R10)`, `[[2]](diffhunk://#diff-168486be9e126a8de1f0588534a9bf2fd49261555cbdc3759a5be2b1d2825cd3R21-R22)`, `[[3]](diffhunk://#diff-c3ade6c0a09b6258d971210f5a41c2ae5beb77873cee44a9ccb78055caf271ddR8-R11)`, `[[4]](diffhunk://#diff-c3ade6c0a09b6258d971210f5a41c2ae5beb77873cee44a9ccb78055caf271ddR20-R30)`, `[[5]](diffhunk://#diff-a52f26710b8c7dac80a95024bb9049e6ba03212f00abc72a7b571a104ac5c54fR14-R15)`, `[[6]](diffhunk://#diff-a52f26710b8c7dac80a95024bb9049e6ba03212f00abc72a7b571a104ac5c54fL22-R25)`, `[[7]](diffhunk://#diff-a52f26710b8c7dac80a95024bb9049e6ba03212f00abc72a7b571a104ac5c54fL35-R39)`, `[[8]](diffhunk://#diff-a52f26710b8c7dac80a95024bb9049e6ba03212f00abc72a7b571a104ac5c54fL122-R127)`)

### Minor Fixes:
* Removed exclusion rule `SA5011` from `.golangci.yaml` to enable static analysis for nil pointer dereference checks. (`[.golangci.yamlL2-L3](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5L2-L3)`)