### PR TITLE
feat: CU-86985axww - Send alert using strategy pattern - factory test

### DIFF
--- a/pkg/sender/factory_test.go
+++ b/pkg/sender/factory_test.go
@@ -1,0 +1,62 @@
+package sender
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubecano/cano-collector/config/destinations"
+	"github.com/kubecano/cano-collector/mocks"
+)
+
+func setupTest(t *testing.T) *SenderFactory {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := mocks.NewMockLoggerInterface(ctrl)
+	mockClient := mocks.NewMockHTTPClient(ctrl)
+
+	return NewSenderFactory(mockLogger, mockClient)
+}
+
+func TestSenderFactory_Create_Slack(t *testing.T) {
+	factory := setupTest(t)
+
+	dest := destinations.Destination{
+		Name:       "slack",
+		WebhookURL: "https://hooks.slack.com/services/XXXX/XXXX",
+	}
+
+	sender, err := factory.Create(dest)
+	assert.NoError(t, err)
+	assert.IsType(t, &SlackSender{}, sender)
+}
+
+func TestSenderFactory_Create_MSTeams(t *testing.T) {
+	factory := setupTest(t)
+
+	dest := destinations.Destination{
+		Name:       "teams",
+		WebhookURL: "https://outlook.office.com/webhook/XXXX",
+	}
+
+	sender, err := factory.Create(dest)
+	assert.NoError(t, err)
+	assert.IsType(t, &MSTeamsSender{}, sender)
+}
+
+func TestSenderFactory_Create_UnsupportedType(t *testing.T) {
+	factory := setupTest(t)
+
+	dest := destinations.Destination{
+		Name:       "pagerduty",
+		WebhookURL: "https://events.pagerduty.com/...",
+	}
+
+	sender, err := factory.Create(dest)
+	assert.Nil(t, sender)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported destination type: pagerduty")
+}

--- a/pkg/sender/factory_test.go
+++ b/pkg/sender/factory_test.go
@@ -10,19 +10,19 @@ import (
 	"github.com/kubecano/cano-collector/mocks"
 )
 
-func setupTest(t *testing.T) *SenderFactory {
+func setupTest(t *testing.T) (*SenderFactory, *gomock.Controller) {
 	t.Helper()
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	mockLogger := mocks.NewMockLoggerInterface(ctrl)
 	mockClient := mocks.NewMockHTTPClient(ctrl)
 
-	return NewSenderFactory(mockLogger, mockClient)
+	return NewSenderFactory(mockLogger, mockClient), ctrl
 }
 
 func TestSenderFactory_Create_Slack(t *testing.T) {
-	factory := setupTest(t)
+	factory, ctrl := setupTest(t)
+	defer ctrl.Finish()
 
 	dest := destinations.Destination{
 		Name:       "slack",
@@ -35,7 +35,8 @@ func TestSenderFactory_Create_Slack(t *testing.T) {
 }
 
 func TestSenderFactory_Create_MSTeams(t *testing.T) {
-	factory := setupTest(t)
+	factory, ctrl := setupTest(t)
+	defer ctrl.Finish()
 
 	dest := destinations.Destination{
 		Name:       "teams",
@@ -48,7 +49,8 @@ func TestSenderFactory_Create_MSTeams(t *testing.T) {
 }
 
 func TestSenderFactory_Create_UnsupportedType(t *testing.T) {
-	factory := setupTest(t)
+	factory, ctrl := setupTest(t)
+	defer ctrl.Finish()
 
 	dest := destinations.Destination{
 		Name:       "pagerduty",

--- a/pkg/sender/factory_test.go
+++ b/pkg/sender/factory_test.go
@@ -3,6 +3,8 @@ package sender
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
@@ -30,7 +32,7 @@ func TestSenderFactory_Create_Slack(t *testing.T) {
 	}
 
 	sender, err := factory.Create(dest)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.IsType(t, &SlackSender{}, sender)
 }
 
@@ -44,7 +46,7 @@ func TestSenderFactory_Create_MSTeams(t *testing.T) {
 	}
 
 	sender, err := factory.Create(dest)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.IsType(t, &MSTeamsSender{}, sender)
 }
 
@@ -59,6 +61,6 @@ func TestSenderFactory_Create_UnsupportedType(t *testing.T) {
 
 	sender, err := factory.Create(dest)
 	assert.Nil(t, sender)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported destination type: pagerduty")
 }


### PR DESCRIPTION
This pull request adds new unit tests for the `SenderFactory` class to ensure it correctly creates different types of senders. The new tests cover the creation of Slack and Microsoft Teams senders, as well as handling unsupported sender types.

Unit tests added for `SenderFactory`:

* [`pkg/sender/factory_test.go`](diffhunk://#diff-ff06539fded2a2fb7194fd1f38e6ca5974e293059595c519d08bc01e5c819530R1-R62): Added `TestSenderFactory_Create_Slack` to verify the creation of `SlackSender` instances.
* [`pkg/sender/factory_test.go`](diffhunk://#diff-ff06539fded2a2fb7194fd1f38e6ca5974e293059595c519d08bc01e5c819530R1-R62): Added `TestSenderFactory_Create_MSTeams` to verify the creation of `MSTeamsSender` instances.
* [`pkg/sender/factory_test.go`](diffhunk://#diff-ff06539fded2a2fb7194fd1f38e6ca5974e293059595c519d08bc01e5c819530R1-R62): Added `TestSenderFactory_Create_UnsupportedType` to verify that unsupported destination types are handled correctly.