### PR TITLE
chore: Refactor destinations yaml config

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -21,11 +21,11 @@ func setupTestLoader(t *testing.T) (Config, error) {
 
 	destinationsConfig := destination.DestinationsConfig{
 		Destinations: struct {
-			Slack []destination.Destination `yaml:"slack"`
-			Teams []destination.Destination `yaml:"teams"`
+			Slack []destination.SlackDestinationConfig `yaml:"slack,omitempty"`
+			Teams []destination.TeamsDestinationConfig `yaml:"teams,omitempty"`
 		}{
-			Slack: []destination.Destination{{Name: "alerts", WebhookURL: "https://slack.example.com"}},
-			Teams: []destination.Destination{},
+			Slack: []destination.SlackDestinationConfig{{BaseDestinationConfig: destination.BaseDestinationConfig{Name: "alerts"}, Token: "xxxx", Channel: "alerts", SigningKey: "xxxx", AccountID: "xxxx", ClusterName: "test-cluster"}},
+			Teams: []destination.TeamsDestinationConfig{{BaseDestinationConfig: destination.BaseDestinationConfig{Name: "alerts"}, WebhookURL: "https://example.com/webhook"}},
 		},
 	}
 	mockDestinations := mocks.NewMockDestinationsLoader(ctrl)

--- a/config/destination/destinations_config_test.go
+++ b/config/destination/destinations_config_test.go
@@ -16,7 +16,8 @@ func TestLoadDestinationsConfig_Success(t *testing.T) {
 destinations:
   slack:
     - name: "incident-alerts"
-      webhookURL: "https://hooks.slack.com/services/XXX"
+      token: "xoxb-1234567890-0987654321-ABCDEF"
+      channel: "#alerts"
   teams:
     - name: "infra-team"
       webhookURL: "https://outlook.office.com/webhook/YYY"
@@ -36,7 +37,8 @@ destinations:
 	// Validate Slack destination
 	assert.Len(t, cfg.Destinations.Slack, 1)
 	assert.Equal(t, "incident-alerts", cfg.Destinations.Slack[0].Name)
-	assert.Equal(t, "https://hooks.slack.com/services/XXX", cfg.Destinations.Slack[0].WebhookURL)
+	assert.Equal(t, "xoxb-1234567890-0987654321-ABCDEF", cfg.Destinations.Slack[0].Token)
+	assert.Equal(t, "#alerts", cfg.Destinations.Slack[0].Channel)
 
 	// Validate Teams destination
 	assert.Len(t, cfg.Destinations.Teams, 1)


### PR DESCRIPTION
This pull request refactors the destination configuration system to introduce more specific configuration types for Slack and Microsoft Teams, improving clarity and validation. Key changes include replacing the generic `Destination` type with `SlackDestinationConfig` and `TeamsDestinationConfig`, adding detailed validation for these configurations, and updating corresponding tests.

### Configuration Refactoring:

* Replaced the generic `Destination` type with `SlackDestinationConfig` and `TeamsDestinationConfig`, each inheriting from a new `BaseDestinationConfig` for shared fields. This change adds support for Slack-specific fields like `Token`, `Channel`, `SigningKey`, `AccountID`, and `ClusterName`.

### Validation Enhancements:

* Added detailed validation for Slack and Teams configurations in `parseDestinationsYAML`, ensuring required fields like `Token` and `Channel` for Slack and `WebhookURL` for Teams are set.

### Test Updates:

* Updated test configurations in `config_test.go` and `destinations_config_test.go` to use the new `SlackDestinationConfig` and `TeamsDestinationConfig` structures. Adjusted assertions to validate the new fields, such as `Token` and `Channel` for Slack. [[1]](diffhunk://#diff-373f5578b8f362a364b50b0d01919a57da64c128547ca10d49df8ae422237c82L24-R28) [[2]](diffhunk://#diff-96eee9f2cc8ae37a98780c487da62f7625540dc3551cc130a6db5383c67917f2L19-R20) [[3]](diffhunk://#diff-96eee9f2cc8ae37a98780c487da62f7625540dc3551cc130a6db5383c67917f2L39-R41)